### PR TITLE
fix action_controller and ActiveSupport compatibility issue with new Rails version

### DIFF
--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -6,8 +6,6 @@
 #
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 
-Rails.application.config.action_controller.raise_on_unfiltered_parameters = true
-
 # Enable per-form CSRF tokens. Previous versions had false.
 Rails.application.config.action_controller.per_form_csrf_tokens = false
 
@@ -20,6 +18,3 @@ ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false
-
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
Code doesn't work out of the box for students. First, running `rails s` show the error

```
2: from /Users//.rvm/gems/ruby-2.6.1/gems/activesupport-5.2.6/lib/active_support/dependencies.rb:285:in `block in load'
1: from /Users//.rvm/gems/ruby-2.6.1/gems/activesupport-5.2.6/lib/active_support/dependencies.rb:285:in `load'
/Users//code/academyxi/phase4/rails-static-request-readme/config/initializers/new_framework_defaults.rb:25:in `<top (required)>': undefined method `halt_callback_chains_on_return_false=' for ActiveSupport:Module (NoMethodError)
```

Removing the line `halt_callback_chains_on_return_false` will fix the above error. but when open the url, it shows
```
Puma caught this error: Invalid option key: raise_on_unfiltered_parameters= (RuntimeError)
/Users//.rvm/gems/ruby-2.6.1/gems/actionpack-5.2.6/lib/action_controller/railtie.rb:63:in `block (3 levels) in <class:Railtie>'
```